### PR TITLE
fix: Resolve About Us image overlapping text

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,10 +95,10 @@
         <div class="container mx-auto">
             <h2 class="text-3xl md:text-4xl font-bold text-center text-orange-600 mb-8 md:mb-12 scroll-animate-fade-in-up">අප ගැන</h2>
             <div class="flex flex-col md:flex-row items-center gap-8 md:gap-10">
-                <div class="md:w-1/2 scroll-animate-fade-in-up">
+                <div class="md:w-1/2 scroll-animate-fade-in-up relative z-10">
                     <img src="https://lh3.googleusercontent.com/gps-cs-s/AC9h4nqOgKYn2cIPobv_PZSU0Eb34w_gshIYCzhdY76SM6O3jSWok_eFe9H042dI0eL43rP_9c89is2d3Um0W7UN3yPnZiOV1tkZ5m5zRDnMmyWknJRz4S7z-v51rxVCIoR_LdlkG2a7=s680-w680-h510-rw" alt="Interior view of Lakshan Stores, showcasing product shelves and a welcoming atmosphere." class="rounded-xl shadow-lg w-full h-auto transform rotate-3 hover:rotate-0 transition-transform duration-500 parallax-image">
                 </div>
-                <div class="md:w-1/2 text-base md:text-lg leading-relaxed text-gray-700 scroll-animate-fade-in-up" style="transition-delay: 0.2s;">
+                <div class="md:w-1/2 text-base md:text-lg leading-relaxed text-gray-700 scroll-animate-fade-in-up relative z-20" style="transition-delay: 0.2s;">
                     <p class="mb-4">
                         ලක්ෂාන් ස්ටෝර්ස් යනු ඔබේ දෛනික අත්‍යවශ්‍ය ද්‍රව්‍ය පහසුවෙන් ඔබේ ස්ථානයටම ලබා දෙන ඔබේ කැපවූ සහකරු වේ. ගබඩාවට පැමිණීමේ අපහසුතාවයකින් තොරව ඔබේ අවශ්‍යතා සපුරාලීමට අවධානය යොමු කරමින්, විශ්වාසනීය සේවාවක් සැපයීමට අපි විශේෂඥයෝ වෙමු.
                     </p>


### PR DESCRIPTION
- Applied `position: relative` and z-index utilities to the image and text containers within the "About Us" section.
- The image container is set to `z-10` and the text container to `z-20`.
- This ensures the text correctly renders on top of the image, preventing overlap issues caused by parallax or other animations.